### PR TITLE
Configuración de atributos de Session en el engine

### DIFF
--- a/app/use_cases/no_password/session_manager.rb
+++ b/app/use_cases/no_password/session_manager.rb
@@ -8,7 +8,7 @@ module NoPassword
       Session.create!(
         user_agent: user_agent,
         email: email,
-        expires_at: Time.zone.now + NoPassword.configuration.session_expiration,
+        expires_at: Time.zone.now.advance(minutes: NoPassword.configuration.session_expiration),
         token: generate_friendly_token,
         remote_addr: remote_addr,
         return_url: return_url

--- a/lib/no_password.rb
+++ b/lib/no_password.rb
@@ -11,7 +11,7 @@ module NoPassword
 
     def initialize
       @session_name = "_session"
-      @session_expiration = 15.minutes
+      @session_expiration = 15
       @session_domain = nil
     end
   end

--- a/test/fixtures/no_password/sessions.yml
+++ b/test/fixtures/no_password/sessions.yml
@@ -8,6 +8,6 @@ session_one:
   token: "NnqE-5854-NUQC"
   user_agent: "Chrome/95.0.4214.45"
   remote_addr: "95.0.4214.45"
-  expires_at: <%= Time.zone.now + NoPassword.configuration.session_expiration %>
+  expires_at: <%= Time.zone.now.advance(minutes: NoPassword.configuration.session_expiration) %>
   return_url: "https://www.creditario.io/home"
   email: "test@example.com"


### PR DESCRIPTION
# Contexto
Se configuraron atributos default de Session en el engine

### Atributos
Los atributos son: session_name, session_expiration y session_domain

### Modificaciones

- Se modificó el archivo lib/no_password.rb con la configuracion default de sessions
- Se modificó el atributo 'expires_at' de SessionManager para usar el de la configuracion del engine
- Se modificó el fixture de session.yml para que obtenga el valor de 'expires_at' desde la configuracion del engine