### PR TITLE
Chore/ Actualización a Rails 7.0.0.rc3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,5 +13,6 @@ gem "turbo-rails"
 
 gem "pg"
 
+gem "sprockets-rails"
 # To use a debugger
 # gem 'byebug', group: [:development, :test]

--- a/no_password.gemspec
+++ b/no_password.gemspec
@@ -23,5 +23,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "standard"
   spec.add_development_dependency "brakeman"
   spec.add_development_dependency "bundle-audit"
-  spec.add_development_dependency "sprockets-rails"
 end

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -1,7 +1,6 @@
 require_relative "boot"
 
 require "rails/all"
-require "sprockets/railtie"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.


### PR DESCRIPTION
# Contexto

- Actualización a Rails 7.0.0.rc3
- También se añade la gema 'sprockets/railtie'