### PR TITLE
Bugfix/Error al iniciar sesión

### DIFF
--- a/app/controllers/no_password/session_confirmations_controller.rb
+++ b/app/controllers/no_password/session_confirmations_controller.rb
@@ -26,8 +26,8 @@ module NoPassword
     private
 
     def sign_in_session(session)
-      SessionManager.new.claim(session.token, session.email)
-      sign_in(session)
+      claimed_session = SessionManager.new.claim(session.token, session.email)
+      sign_in(claimed_session)
 
       redirect_to session.return_url || main_app.root_path
     end

--- a/test/controllers/no_password/session_confirmations_controller_test.rb
+++ b/test/controllers/no_password/session_confirmations_controller_test.rb
@@ -13,6 +13,13 @@ module NoPassword
       assert_redirected_to session.return_url
     end
 
+    test "it checks if session gets claimed" do
+      session = no_password_sessions(:session_one)
+      claimed_session = SessionManager.new.claim(session.token, session.email)
+
+      assert claimed_session.claimed?
+    end
+
     test "it shows error notification if token is invalid after using magic link" do
       get no_password.session_confirmation_path(token: "invalid_token")
 


### PR DESCRIPTION
-Se corrigió un error al iniciar sesión, antes usaba la sesión recibida en el parámetro y no la sesión reclamada en el método session_confirmations_controller#sign_in_session al hacer sign_in.