### PR TITLE
Chore/Actualizar git ignore y manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ log/*.log
 pkg/
 tmp/*/*/*
 
+#Ignore tailwind.config.js created in engine
+app/assets/config/no_password/tailwind.config.js
+
 # Ignore dummy files.
 test/dummy/db/*.sqlite3
 test/dummy/db/*.sqlite3-*

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,6 +130,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.1-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.1-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.1-x86_64-linux)
       racc (~> 1.4)
     parallel (1.21.0)
@@ -203,6 +205,8 @@ GEM
     strscan (3.0.1)
     tailwindcss-rails (2.0.5-arm64-darwin)
       railties (>= 6.0.0)
+    tailwindcss-rails (2.0.5-x86_64-darwin)
+      railties (>= 6.0.0)
     tailwindcss-rails (2.0.5-x86_64-linux)
       railties (>= 6.0.0)
     thor (1.2.1)
@@ -220,6 +224,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-20
+  x86_64-darwin-19
   x86_64-linux
 
 DEPENDENCIES

--- a/test/dummy/app/assets/config/manifest.js
+++ b/test/dummy/app/assets/config/manifest.js
@@ -1,6 +1,7 @@
 //= link_tree ../images
 //= link_tree ../../javascript/controllers .js
 //= link application.css
+//= link application.js
 
 //= link_tree ../../../vendor/javascript .js
 //= link_tree ../builds

--- a/test/dummy/app/assets/config/manifest.js
+++ b/test/dummy/app/assets/config/manifest.js
@@ -1,6 +1,5 @@
 //= link_tree ../images
-//= link_directory ../stylesheets .css
+//= link_tree ../../javascript/controllers .js
 
-//= link_tree ../../javascript .js
 //= link_tree ../../../vendor/javascript .js
 //= link_tree ../builds

--- a/test/dummy/app/assets/config/manifest.js
+++ b/test/dummy/app/assets/config/manifest.js
@@ -1,5 +1,6 @@
 //= link_tree ../images
 //= link_tree ../../javascript/controllers .js
+//= link application.css
 
 //= link_tree ../../../vendor/javascript .js
 //= link_tree ../builds


### PR DESCRIPTION
El motivo de este chore es restaurar el funcionamiento de dummy.

- Se actualiza el **.gitignore** para ignorar el archivo **app/assets/config/no_password/tailwind.config.js** que se genera al hacer `$ overmind start` ó `$ ./bin/dev`.
- Se actualiza manifest para resolver error "_Multiple files with the same output path cannot be linked_" con **application.css** y **application.js**, porque ya se buscan con `link_tree ../builds`.