### PR TITLE
Referer no siempre está presente.

### DIFF
--- a/app/controllers/no_password/concerns/controller_helpers.rb
+++ b/app/controllers/no_password/concerns/controller_helpers.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/concern"
-
 module NoPassword
   module Concerns
     module ControllerHelpers
@@ -18,10 +16,7 @@ module NoPassword
         end
 
         def authenticate_session!
-          unless signed_in_session?
-            session[:referrer_path] = request.fullpath
-            redirect_to no_password.new_session_path, alert: t("flash.update.session.alert")
-          end
+          redirect_to no_password.new_session_path(return_to: CGI.escape(request.fullpath)), alert: t("flash.update.session.alert") unless signed_in_session?
         end
 
         helper_method :current_session, :signed_in_session?

--- a/app/views/no_password/sessions/new.html.erb
+++ b/app/views/no_password/sessions/new.html.erb
@@ -8,7 +8,7 @@
     </div>
     <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
       <div class="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
-        <%= form_with model: @resource, local: true, url: no_password.sessions_path, class: "space-y-6" do |form| %>
+        <%= form_with model: @resource, local: true, url: no_password.sessions_path(return_to: @return_to), class: "space-y-6" do |form| %>
           <p class="text-skin-muted px-4 text-center">
               <%= t("no_password.sessions.new.description") %>
           </p>

--- a/test/controllers/no_password/concerns/controller_helpers_test.rb
+++ b/test/controllers/no_password/concerns/controller_helpers_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module NoPassword
@@ -31,10 +33,11 @@ module NoPassword
     end
 
     test "it checks 'authenticate_session!' functionality, it can't access to main_app.home_path if signed_in_session? is false" do
-      get "/home/1"
+      path = "/home/1"
+      get path
 
       refute @controller.signed_in_session?
-      assert_redirected_to no_password.new_session_path
+      assert_redirected_to no_password.new_session_path(return_to: CGI.escape(path))
     end
   end
 end

--- a/test/controllers/no_password/session_confirmations_controller_test.rb
+++ b/test/controllers/no_password/session_confirmations_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module NoPassword

--- a/test/controllers/no_password/sessions_controller_test.rb
+++ b/test/controllers/no_password/sessions_controller_test.rb
@@ -1,19 +1,9 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module NoPassword
   class SessionsControllerTest < ActionDispatch::IntegrationTest
-    test "referer_path is nil if HTTP_REFERER is originated from engine's new_session_path" do
-      get no_password.new_session_path, headers: {HTTP_REFERER: no_password.new_session_url}
-
-      assert_nil session[:referrer_path]
-    end
-
-    test "referer_path is present if HTTP_REFERER is originated from a internal url" do
-      get no_password.new_session_path, headers: {HTTP_REFERER: no_password.sessions_url}
-
-      assert session[:referrer_path]
-    end
-
     test "it creates a session with nil referer_path if HTTP_REFERER is originated from engine's new_session_path" do
       get no_password.new_session_path, headers: {HTTP_REFERER: no_password.new_session_url}
       post no_password.sessions_path, params: {session: {email: "ana@example.com"}}, headers: {HTTP_USER_AGENT: "Mozilla/5.0"}
@@ -29,14 +19,13 @@ module NoPassword
     end
 
     test "it creates a session with referer_path if HTTP_REFERER is originated from an internal url" do
-      get no_password.new_session_path, headers: {HTTP_REFERER: no_password.sessions_url}
-      post no_password.sessions_path, params: {session: {email: "ana@example.com"}}, headers: {HTTP_USER_AGENT: "Mozilla/5.0"}
+      post no_password.sessions_path, params: {session: {email: "ana@example.com"}}, headers: {HTTP_USER_AGENT: "Mozilla/5.0", HTTP_REFERER: "/secure_place"}
 
       assert NoPassword::Session.last.return_url
     end
 
-    test "it redirects to redirect_to no_password.edit_session_confirmations_path if current_session.present?" do
-      get no_password.new_session_path, headers: {HTTP_REFERER: no_password.sessions_url}
+    test "it redirects to no_password.edit_session_confirmations_path if current_session.present?" do
+      get no_password.new_session_path, headers: {HTTP_REFERER: "/secure_place"}
       post no_password.sessions_path, params: {session: {email: "ana@example.com"}}, headers: {HTTP_USER_AGENT: "Mozilla/5.0"}
 
       assert_redirected_to no_password.edit_session_confirmations_path

--- a/test/integration/navigation_test.rb
+++ b/test/integration/navigation_test.rb
@@ -1,10 +1,13 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class NavigationTest < ActionDispatch::IntegrationTest
   test "It redirects to no_password.new_session_path if no session is currently active" do
-    get "/home/1"
+    path = "/home/1"
+    get path
 
-    assert_redirected_to no_password.new_session_path
+    assert_redirected_to no_password.new_session_path(return_to: CGI.escape(path))
   end
 
   test "It shows No active session title on Home#index if no session is currently active" do


### PR DESCRIPTION
De acuerdo con la documentación el encabezado de
HTTP_REFERER no se coloca por el navegador cuando:

- Entered the site URL in browser address bar itself.
- Visited the site by a browser-maintained bookmark.
- Visited the site as first page in the window/tab.
- Clicked a link in an external application.
- Switched from a https URL to a http URL.
- Switched from a https URL to a different https URL.
- Has security software installed (antivirus/firewall/etc) which strips the referrer from all requests.
is behind a proxy which strips the referrer from all requests.

El path para redirgir de la gema debe ser solamente
interno, no debe de redirigir nunca a un lugar externo.
El camino de guardar el requets.fullpath que contiene
un path interno en authenticate_session! era el correcto.
Sin embargo el código quedó abandonado.

El cambio consiste en utilizar el request.fullpath
unicamente cuando se ha negado el acceso vía
authenticate_session! y no de alguna otra forma.
El valor se agrega a la URL en lugar de guardar el
valor en sesión.