### PR TITLE
chore/Modifica Referrer Path en SessionsController

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -225,6 +225,7 @@ GEM
 PLATFORMS
   arm64-darwin-20
   x86_64-darwin-19
+  x86_64-darwin-20
   x86_64-linux
 
 DEPENDENCIES
@@ -242,4 +243,4 @@ DEPENDENCIES
   turbo-rails
 
 BUNDLED WITH
-   2.2.21
+   2.3.5

--- a/app/controllers/no_password/sessions_controller.rb
+++ b/app/controllers/no_password/sessions_controller.rb
@@ -27,7 +27,7 @@ module NoPassword
     private
 
     def referrer_path(return_to)
-      referrer = request.referrer.present? ? URI(request.referrer).path : CGI.unescape(return_to)
+      referrer = CGI.unescape(return_to)
       return nil if referrer.blank?
 
       referrer.include?(no_password.new_session_path) || referrer.include?(no_password.edit_session_confirmations_path) ? nil : referrer

--- a/test/controllers/no_password/sessions_controller_test.rb
+++ b/test/controllers/no_password/sessions_controller_test.rb
@@ -4,35 +4,35 @@ require "test_helper"
 
 module NoPassword
   class SessionsControllerTest < ActionDispatch::IntegrationTest
-    test "it creates a session with nil referer_path if HTTP_REFERER is originated from engine's new_session_path" do
-      get no_password.new_session_path, headers: {HTTP_REFERER: no_password.new_session_url}
-      post no_password.sessions_path, params: {session: {email: "ana@example.com"}}, headers: {HTTP_USER_AGENT: "Mozilla/5.0"}
+    test "it creates a session with nil referer_path if return_to path is engine's new_session_path" do
+      get no_password.new_session_url
+      post no_password.sessions_path(return_to: CGI.escape(request.fullpath)), params: {session: {email: "ana@example.com"}}, headers: {HTTP_USER_AGENT: "Mozilla/5.0"}
 
       assert_nil NoPassword::Session.last.return_url
     end
 
-    test "it creates a session with nil referer_path if HTTP_REFERER is originated from engine's edit_session_confirmations_path" do
-      get no_password.new_session_path, headers: {HTTP_REFERER: no_password.edit_session_confirmations_path}
-      post no_password.sessions_path, params: {session: {email: "ana@example.com"}}, headers: {HTTP_USER_AGENT: "Mozilla/5.0"}
+    test "it creates a session with nil referer_path if return_to path is engine's edit_session_confirmations_path" do
+      get no_password.edit_session_confirmations_path
+      post no_password.sessions_path(return_to: CGI.escape(request.fullpath)), params: {session: {email: "ana@example.com"}}, headers: {HTTP_USER_AGENT: "Mozilla/5.0"}
 
       assert_nil NoPassword::Session.last.return_url
     end
 
-    test "it creates a session with referer_path if HTTP_REFERER is originated from an internal url" do
-      post no_password.sessions_path, params: {session: {email: "ana@example.com"}}, headers: {HTTP_USER_AGENT: "Mozilla/5.0", HTTP_REFERER: "/secure_place"}
+    test "it creates a session with referer_path if return_to path is an internal url" do
+      path = "/home/1"
+      get path
+      post no_password.sessions_path(return_to: CGI.escape(path)), params: {session: {email: "ana@example.com"}}, headers: {HTTP_USER_AGENT: "Mozilla/5.0"}
 
       assert NoPassword::Session.last.return_url
     end
 
-    test "it redirects to no_password.edit_session_confirmations_path if current_session.present?" do
-      get no_password.new_session_path, headers: {HTTP_REFERER: "/secure_place"}
+    test "it redirects to no_password.edit_session_confirmations_path after send form with email" do
       post no_password.sessions_path, params: {session: {email: "ana@example.com"}}, headers: {HTTP_USER_AGENT: "Mozilla/5.0"}
 
       assert_redirected_to no_password.edit_session_confirmations_path
     end
 
     test "it destroys a session and redirects to main_app.root_path" do
-      get no_password.new_session_path, headers: {HTTP_REFERER: no_password.new_session_url}
       post no_password.sessions_path, params: {session: {email: "ana@example.com"}}, headers: {HTTP_USER_AGENT: "Mozilla/5.0"}
       patch no_password.session_confirmations_path(token: NoPassword::Session.last.token)
 


### PR DESCRIPTION
# Contexto
Utilizar `request.referrer` estaba causando interferencia al momento de guardar el `return_url`, provocando que en ocasiones este fuera `nil`, esto hacia que el usuario siempre fuera redirigido al `root_path` en lugar de a la vista que originalmente consultó.
Se retiró el uso de `referrer` para cambiarlo por el parámetro `return_to` que es el `request.fullpath` de la dirección previa y viene incluido en el URL.

# Cambios
- Se elimina el uso de request.referrer y se deja unicamente utilizando el valor del parametro return_to del URL
- Se adaptaron los test ahora que ya no se utilizar el referrer