### PR TITLE
Feature/personaliza respuestas

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,11 +128,11 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
-    nokogiri (1.13.1-arm64-darwin)
+    nokogiri (1.13.3-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.13.1-x86_64-darwin)
+    nokogiri (1.13.3-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.13.1-x86_64-linux)
+    nokogiri (1.13.3-x86_64-linux)
       racc (~> 1.4)
     parallel (1.21.0)
     parser (3.1.0.0)
@@ -226,6 +226,7 @@ PLATFORMS
   arm64-darwin-20
   x86_64-darwin-19
   x86_64-darwin-20
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ NoPassword permite realizar autenticación de sesiones con un token o un link m�
 - [Uso](#uso)
   - [Filtros de controlador y helpers](#filtros-de-controlador-y-helpers)
   - [Helper methods](#helper-methods)
+  - [Callbacks](#callbacks)
   - [Rutas](#rutas)
 - [Generadores disponibles](#generadores-disponibles)
 - [Instalación de requerimientos](#instalación-de-requerimientos)
@@ -169,6 +170,44 @@ Este es un ejemplo de como se usan en las vistas:
 Al finalizar la instalación y configuración de la gema puedes probar tu aplicación con el comando `./bin/dev`
 ```bash
 $ ./bin/dev
+```
+
+### Callbacks
+
+Si requieres tener más control sobre lo que pasa después de hacer login, tienes disponible el siguiente callback:
+```ruby
+after_sign_in!(signed_in, by_url)
+```
+#### Parámetros
+
+El callback tiene dos parámetros que funcionan de la siguiente manera:
+
+El valor de `signed_in` es `true` cuando la sesión se inicia exitosamente y su valor es `false` cuando no.
+
+El valor de `by_url` es `true` cuando intentas iniciar sesión por medio del link y su valor es `false` cuando ingresas el token manualmente en el formulario.
+
+#### Ejemplo
+
+Para implementarlo, añade el método `after_sign_in!` dentro del controlador `session_confirmations_controller.rb` mediante un `class.eval`.
+
+Un ejemplo de cómo utilizar el callback:
+
+```ruby
+load NoPassword::Engine.root.join("app", "controllers", "no_password", "session_confirmations_controller.rb")
+
+NoPassword::SessionConfirmationsController.class_eval do
+  private
+
+  def after_sign_in!(signed_in, by_url)
+    return example_method if signed_in
+    return nil unless by_url
+
+    flash[:alert] = "No es posible iniciar sesión"
+    redirect_to main_app.example_path
+  end
+
+  ...
+end
 ```
 
 ### Rutas

--- a/app/controllers/no_password/session_confirmations_controller.rb
+++ b/app/controllers/no_password/session_confirmations_controller.rb
@@ -10,22 +10,31 @@ module NoPassword
         friendly_token = verify_token(params[:token])
 
         current_session = find_and_validate_token(friendly_token)
-        return sign_in_session(current_session) if current_session.present?
+
+        if !current_session.present? && respond_to?(:custom_redirect)
+          custom_redirect
+        elsif current_session.present?
+          sign_in_session(current_session)
+        end
       end
     end
 
     def update
       current_session = find_and_validate_token(params[:token])
 
-      return sign_in_session(current_session) if current_session.present?
-
-      response.status = :unprocessable_entity
-      render turbo_stream: turbo_stream.update("notifications", partial: "notification")
+      if !current_session.present? && respond_to?(:custom_redirect)
+        custom_redirect
+      elsif current_session.present?
+        sign_in_session(current_session)
+      else
+        response.status = :unprocessable_entity
+        render turbo_stream: turbo_stream.update("notifications", partial: "notification")
+      end
     end
 
     private
 
-    def sign_in(session_model, key = nil, data = nil)
+    def nopassword_sign_in(session_model, key = nil, data = nil)
       if session_model.claimed? && !session_model.expired?
         session[session_key] = session_model.id
 
@@ -38,9 +47,13 @@ module NoPassword
 
     def sign_in_session(session)
       claimed_session = SessionManager.new.claim(session.token, session.email)
-      sign_in(claimed_session)
+      nopassword_sign_in(claimed_session)
 
-      redirect_to session.return_url || main_app.root_path
+      if respond_to?(:force_device_login)
+        force_device_login
+      else
+        redirect_to session.return_url || main_app.root_path
+      end
     end
 
     def find_and_validate_token(friendly_token)

--- a/app/controllers/no_password/session_confirmations_controller.rb
+++ b/app/controllers/no_password/session_confirmations_controller.rb
@@ -9,7 +9,7 @@ module NoPassword
       if params[:token].present?
         friendly_token = verify_token(params[:token])
 
-        sign_in_session(friendly_token)
+        sign_in_session(friendly_token, true)
       end
     end
 
@@ -23,23 +23,23 @@ module NoPassword
 
     private
 
-    def sign_in_session(friendly_token)
+    def sign_in_session(friendly_token, by_url = false)
       current_session = find_and_validate_token(friendly_token)
 
       result = if current_session.blank? && respond_to?(:after_sign_in!)
-        after_sign_in!(false)
+        after_sign_in!(false, by_url)
       elsif current_session.present?
-        claim_session(current_session)
+        claim_session(current_session, by_url)
       end
 
       result if result.present?
     end
 
-    def claim_session(session)
+    def claim_session(session, by_url = false)
       claimed_session = SessionManager.new.claim(session.token, session.email)
       save_session_to_cookie(claimed_session)
 
-      return after_sign_in!(true) if respond_to?(:after_sign_in!)
+      return after_sign_in!(true, by_url) if respond_to?(:after_sign_in!)
 
       redirect_to session.return_url || main_app.root_path
     end

--- a/app/controllers/no_password/sessions_controller.rb
+++ b/app/controllers/no_password/sessions_controller.rb
@@ -15,7 +15,11 @@ module NoPassword
 
       if current_session.present?
         SessionsMailer.with(session: current_session).send_token.deliver_now
-        redirect_to no_password.edit_session_confirmations_path
+
+        respond_to do |format|
+          format.html { redirect_to no_password.edit_session_confirmations_path }
+          format.turbo_stream
+        end
       end
     end
 

--- a/app/controllers/no_password/sessions_controller.rb
+++ b/app/controllers/no_password/sessions_controller.rb
@@ -16,6 +16,8 @@ module NoPassword
       if current_session.present?
         SessionsMailer.with(session: current_session).send_token.deliver_now
 
+        after_session_request if respond_to?(:after_session_request)
+
         respond_to do |format|
           format.html { redirect_to no_password.edit_session_confirmations_path }
           format.turbo_stream

--- a/app/views/no_password/session_confirmations/_form.html.erb
+++ b/app/views/no_password/session_confirmations/_form.html.erb
@@ -1,0 +1,19 @@
+<%= turbo_frame_tag :form do %>
+  <%= form_with url: no_password.session_confirmations_path, method: "patch", class: "space-y-6", html: { "data-turbo-frame": "_top" } do |form| %>
+    <p class="text-skin-muted px-4 text-center">
+      <%= t("no_password.session_confirmations.edit.description") %>
+    </p>
+    <div>
+      <label class="block text-sm font-medium text-skin-muted"><%= form.label t("form.labels.token") %></label>
+      <div class="mt-1">
+        <%= form.text_field :token, maxlength: 60, required: true, class: "input w-full", type: "text", placeholder: t("form.placeholders.token") %>
+      </div>
+    </div>
+    <div>
+      <%= form.submit t("form.submit.login"), class: "w-full flex button button-accented" %>
+    </div>
+    <div>
+      <%= link_to t("no_password.session_confirmations.edit.request_token"), no_password.new_session_path, class: "w-full block text-center text-skin-accented hover:text-skin-accented-hover", "data-turbo": false %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/no_password/session_confirmations/edit.html.erb
+++ b/app/views/no_password/session_confirmations/edit.html.erb
@@ -8,23 +8,7 @@
     </div>
     <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
       <div class="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
-        <%= form_with url: no_password.session_confirmations_path, method: "patch", class: "space-y-6" do |form| %>
-          <p class="text-skin-muted px-4 text-center">
-            <%= t("no_password.session_confirmations.edit.description") %>
-          </p>
-          <div>
-            <label class="block text-sm font-medium text-skin-muted"><%= form.label t("form.labels.token") %></label>
-            <div class="mt-1">
-              <%= form.text_field :token, maxlength: 60, required: true, class: "input w-full", type: "text", placeholder: t("form.placeholders.token") %>
-            </div>
-          </div>
-          <div>
-            <%= form.submit t("form.submit.login"), class: "w-full flex button button-accented" %>
-          </div>
-          <div>
-            <%= link_to t("no_password.session_confirmations.edit.request_token"), no_password.new_session_path, class: "w-full block text-center text-skin-accented hover:text-skin-accented-hover" %>
-          </div>
-        <% end %>
+        <%= render partial: "form" %>
       </div>
     </div>
   </div>

--- a/app/views/no_password/sessions/create.turbo_stream.erb
+++ b/app/views/no_password/sessions/create.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace :form do %>
+  <%= render partial: "no_password/session_confirmations/form" %>
+<% end %>

--- a/app/views/no_password/sessions/new.html.erb
+++ b/app/views/no_password/sessions/new.html.erb
@@ -8,19 +8,21 @@
     </div>
     <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
       <div class="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
-        <%= form_with model: @resource, local: true, url: no_password.sessions_path(return_to: @return_to), class: "space-y-6" do |form| %>
-          <p class="text-skin-muted px-4 text-center">
-              <%= t("no_password.sessions.new.description") %>
-          </p>
-          <div>
-            <label class="block text-sm font-medium text-skin-muted"><%= form.label :email %></label>
-            <div class="mt-1">
-              <%= form.text_field :email, maxlength: 60, required: true, class: "input w-full", type: "email", placeholder: t("form.placeholders.email") %>
+        <%= turbo_frame_tag :form do %>
+          <%= form_with model: @resource, local: true, url: no_password.sessions_path(return_to: @return_to), class: "space-y-6", html: {"data-turbo": false} do |form| %>
+            <p class="text-skin-muted px-4 text-center">
+                <%= t("no_password.sessions.new.description") %>
+            </p>
+            <div>
+              <label class="block text-sm font-medium text-skin-muted"><%= form.label :email %></label>
+              <div class="mt-1">
+                <%= form.text_field :email, maxlength: 60, required: true, class: "input w-full", type: "email", placeholder: t("form.placeholders.email") %>
+              </div>
             </div>
-          </div>
-          <div>
-              <%= form.submit t("form.submit.login"), class: "w-full flex button button-accented" %>
-          </div>
+            <div>
+                <%= form.submit t("form.submit.login"), class: "w-full flex button button-accented" %>
+            </div>
+          <% end %>
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
- Se extrajo el formulario de confirmación a que sea un parcial para
poder responder con él desde turbo.
- Se ajustaron links y formularios para responder ya sea HTML o Turbo.
- Se añadieron hooks en SessionConfirmationController para manejar redireccionamientos en edit y update.
- Se cambió provisionalmente el método de sign_in para evitar conflictos con el método de sign_in en devise.
- Se actualizó nokogiri para resolver vulnerabilidades en CI.
- Reorganiza el código de SessionConfirmationsController, renombrando
métodos privados y siguiendo nombre estandar para Callbacks.
- Agrega Callback para cuando se solicita una sesión.